### PR TITLE
include abort controller polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^10.0.0",
     "@types/node-fetch": "^2.1.7",
     "@types/validator": "^10.11.0",
-    "abort-controller": "^1.0.2",
+    "abort-controller": "^3.0.0",
     "danger": "^7.1.2",
     "danger-plugin-digitalcitizenship": "^0.3.1",
     "italia-tslint-rules": "^1.1.3",

--- a/src/__tests__/fetch.test.ts
+++ b/src/__tests__/fetch.test.ts
@@ -1,15 +1,5 @@
-import { AbortController } from "abort-controller";
 import ServerMock = require("mock-http-server");
-import nodeFetch, { FetchError } from "node-fetch";
-
-//
-// We need to override the global fetch and AbortController to make the tests
-// compatible with node-fetch
-//
-// tslint:disable-next-line:no-object-mutation no-any
-(global as any).fetch = nodeFetch;
-// tslint:disable-next-line:no-object-mutation no-any
-(global as any).AbortController = AbortController;
+import nodeFetch from "node-fetch";
 
 import {
   AbortableFetch,
@@ -17,9 +7,12 @@ import {
   setFetchTimeout,
   toFetch
 } from "../fetch";
-import { timeoutPromise, withTimeout, DeferredPromise } from "../promises";
+import { DeferredPromise, timeoutPromise } from "../promises";
 import { MaxRetries, RetryAborted, withRetries } from "../tasks";
 import { Millisecond } from "../units";
+
+// tslint:disable-next-line: no-any no-object-mutation
+(global as any).fetch = nodeFetch;
 
 const TEST_HOST = "localhost";
 const TEST_PORT = 40000;
@@ -67,6 +60,7 @@ describe("AbortableFetch", () => {
     await timeoutPromise(100 as Millisecond);
     abortController.abort();
 
+    // tslint:disable-next-line: no-floating-promises
     expect(responsePromise).rejects.toEqual(
       expect.objectContaining({
         message: "The user aborted a request."
@@ -154,6 +148,7 @@ describe("retriableFetch", () => {
     )(timeoutFetch);
 
     // stop retrying after 100ms
+    // tslint:disable-next-line: no-floating-promises
     timeoutPromise(100 as Millisecond).then(() => resolveShouldAbort(true));
 
     try {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -13,6 +13,9 @@ import {
 import { ITuple2, Tuple2 } from "./tuples";
 import { Millisecond } from "./units";
 
+// tslint:disable-next-line: no-submodule-imports
+import "abort-controller/polyfill";
+
 /**
  * An instance of fetch, along its associated AbortController
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -414,12 +414,12 @@ abab@^2.0.0:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
   integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
 
-abort-controller@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-1.1.0.tgz#89b6dbb47a2efcc3101bcd5c7868f87709528130"
-  integrity sha512-W7tP1xDfZFz1b7N59UBPwg/d9fIle1XZBuHU3BL2DDl38mHQz2bCKHyH+un5C/SN8a4u2GbutFCOVk7QmgL/fg==
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
   dependencies:
-    event-target-shim "^3.0.0"
+    event-target-shim "^5.0.0"
 
 acorn-globals@^1.0.4:
   version "1.0.9"
@@ -2018,10 +2018,10 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-event-target-shim@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-3.0.2.tgz#af25bb55a97c670bbeba985c82647fb64d892153"
-  integrity sha512-HK5GhnEAkm7fLy249GtF7DIuYmjLm85Ft6ssj7DhVl8Tx/z9+v0W6aiIVUdT4AXWGYy5Fc+s6gqBI49Bf0LejQ==
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 exec-sh@^0.2.0:
   version "0.2.2"


### PR DESCRIPTION
this includes abort-controller polyfill in order to avoid to manually assign `global.AbortController` in the projects that are using the fetch module:

https://github.com/pagopa/io-app/blob/58cb48ef130d1b398a7ae45f61a81b272b93a773/ts/utils/fetch.ts#L61

https://github.com/pagopa/io-app/blob/58cb48ef130d1b398a7ae45f61a81b272b93a773/ts/utils/fetch.ts#L104

https://github.com/pagopa/io-functions-services/blob/574d61be2bf1d6e05e9015c495273de881b26fee/WebhookNotificationActivity/handler.ts#L113

https://github.com/pagopa/io-functions-app/blob/3aeb18eb0d1c3d5e4e8cfa5e7cf37b8ad2740ffd/SendWelcomeMessagesActivity/index.ts#L128

I'll create a major release.