### PR TITLE
[#173401371] safe appinsight defaultClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "abort-controller": "^3.0.0",
     "agentkeepalive": "^4.1.2",
-    "applicationinsights": "^1.7.4",
+    "applicationinsights": "^1.8.0",
     "fp-ts": "1.17.4",
     "io-ts": "1.8.5",
     "json-set-map": "^1.0.2",

--- a/src/__tests__/appinsights.test.ts
+++ b/src/__tests__/appinsights.test.ts
@@ -1,10 +1,10 @@
+// tslint:disable: no-any
+
 import * as appInsights from "applicationinsights";
 import { Configuration } from "applicationinsights";
-import { SlowBuffer } from "buffer";
 import {
   defaultClient,
   initAppInsights,
-  ITelemetryDefaultClient,
   removeQueryParamsPreprocessor
 } from "../appinsights";
 
@@ -106,7 +106,8 @@ describe("defaultClient Proxy", () => {
         appInsights.defaultClient[
           opName as keyof typeof appInsights.defaultClient
         ];
-      const proxied = defaultClient[opName as keyof ITelemetryDefaultClient];
+      const proxied =
+        defaultClient[opName as keyof typeof appInsights.defaultClient];
       expect(typeof native).toBe(typeof proxied);
     });
   });
@@ -134,7 +135,7 @@ describe("defaultClient Proxy", () => {
       methodName,
       args
     }: {
-      methodName: keyof ITelemetryDefaultClient;
+      methodName: keyof typeof appInsights.defaultClient;
       args: readonly any[];
     }) => {
       jest.doMock("applicationinsights", () => {
@@ -178,7 +179,7 @@ describe("defaultClient Proxy", () => {
       methodName,
       args
     }: {
-      methodName: keyof ITelemetryDefaultClient;
+      methodName: keyof typeof appInsights.defaultClient;
       args: readonly any[];
     }) => {
       jest.doMock("applicationinsights", () => {

--- a/src/appinsights.ts
+++ b/src/appinsights.ts
@@ -178,8 +178,18 @@ export const defaultClient: typeof appInsights.defaultClient = appInsights.defau
       {},
       {
         // tslint:disable-next-line: no-any
-        get(): () => void {
-          return () => void 0;
+        // tslint:disable-next-line: typedef
+        get(_, name: string) {
+          const objectProps: ReadonlyArray<keyof typeof appInsights.defaultClient> = [
+            "config",
+            "context",
+            "commonProperties",
+            "channel",
+            "quickPulseClient"
+          ];
+          return (objectProps as readonly string[]).includes(name)
+            ? {}
+            : () => void 0;
         }
       }
     ) as typeof appInsights.defaultClient);

--- a/src/appinsights.ts
+++ b/src/appinsights.ts
@@ -167,47 +167,19 @@ export function initAppInsights(
   });
 }
 
-// tslint:disable-next-line: no-any
-const noop = (..._: readonly any[]): void => void 0;
-export interface ITelemetryDefaultClient {
-  addTelemetryProcessor: typeof appInsights.defaultClient.addTelemetryProcessor;
-  clearTelemetryProcessors: typeof appInsights.defaultClient.addTelemetryProcessor;
-  flush: typeof appInsights.defaultClient.flush;
-  track: typeof appInsights.defaultClient.track;
-  trackAvailability: typeof appInsights.defaultClient.trackAvailability;
-  trackDependency: typeof appInsights.defaultClient.trackDependency;
-  trackEvent: typeof appInsights.defaultClient.trackEvent;
-  trackException: typeof appInsights.defaultClient.trackException;
-  trackMetric: typeof appInsights.defaultClient.trackMetric;
-  trackNodeHttpDependency: typeof appInsights.defaultClient.trackNodeHttpDependency;
-  trackNodeHttpRequest: typeof appInsights.defaultClient.trackNodeHttpRequest;
-  trackNodeHttpRequestSync: typeof appInsights.defaultClient.trackNodeHttpRequestSync;
-  trackPageView: typeof appInsights.defaultClient.trackPageView;
-  trackRequest: typeof appInsights.defaultClient.trackRequest;
-  trackTrace: typeof appInsights.defaultClient.trackTrace;
-}
-
 /**
  * Wraps ApplicationInsights' defaultClient to provide a version which is never undefined.
  * ApplicationInsights' defaultClient is instantiated as a singleton inside its module. If no env configuration is provided, this results to be undefined and forces user to check everytime before using it
  * In case is not defined, we provide a dummy clone in which its methods results in no-operations, avoiding unhandled exceptions.
  */
-export const defaultClient: ITelemetryDefaultClient = appInsights.defaultClient
+export const defaultClient: typeof appInsights.defaultClient = appInsights.defaultClient
   ? appInsights.defaultClient
-  : {
-      addTelemetryProcessor: noop,
-      clearTelemetryProcessors: noop,
-      flush: noop,
-      track: noop,
-      trackAvailability: noop,
-      trackDependency: noop,
-      trackEvent: noop,
-      trackException: noop,
-      trackMetric: noop,
-      trackNodeHttpDependency: noop,
-      trackNodeHttpRequest: noop,
-      trackNodeHttpRequestSync: noop,
-      trackPageView: noop,
-      trackRequest: noop,
-      trackTrace: noop
-    };
+  : (new Proxy(
+      {},
+      {
+        // tslint:disable-next-line: no-any
+        get(): () => void {
+          return () => void 0;
+        }
+      }
+    ) as typeof appInsights.defaultClient);

--- a/src/appinsights.ts
+++ b/src/appinsights.ts
@@ -166,3 +166,48 @@ export function initAppInsights(
     ...agentOpts
   });
 }
+
+// tslint:disable-next-line: no-any
+const noop = (..._: readonly any[]): void => void 0;
+export interface ITelemetryDefaultClient {
+  addTelemetryProcessor: typeof appInsights.defaultClient.addTelemetryProcessor;
+  clearTelemetryProcessors: typeof appInsights.defaultClient.addTelemetryProcessor;
+  flush: typeof appInsights.defaultClient.flush;
+  track: typeof appInsights.defaultClient.track;
+  trackAvailability: typeof appInsights.defaultClient.trackAvailability;
+  trackDependency: typeof appInsights.defaultClient.trackDependency;
+  trackEvent: typeof appInsights.defaultClient.trackEvent;
+  trackException: typeof appInsights.defaultClient.trackException;
+  trackMetric: typeof appInsights.defaultClient.trackMetric;
+  trackNodeHttpDependency: typeof appInsights.defaultClient.trackNodeHttpDependency;
+  trackNodeHttpRequest: typeof appInsights.defaultClient.trackNodeHttpRequest;
+  trackNodeHttpRequestSync: typeof appInsights.defaultClient.trackNodeHttpRequestSync;
+  trackPageView: typeof appInsights.defaultClient.trackPageView;
+  trackRequest: typeof appInsights.defaultClient.trackRequest;
+  trackTrace: typeof appInsights.defaultClient.trackTrace;
+}
+
+/**
+ * Wraps ApplicationInsights' defaultClient to provide a version which is never undefined.
+ * ApplicationInsights' defaultClient is instantiated as a singleton inside its module. If no env configuration is provided, this results to be undefined and forces user to check everytime before using it
+ * In case is not defined, we provide a dummy clone in which its methods results in no-operations, avoiding unhandled exceptions.
+ */
+export const defaultClient: ITelemetryDefaultClient = appInsights.defaultClient
+  ? appInsights.defaultClient
+  : {
+      addTelemetryProcessor: noop,
+      clearTelemetryProcessors: noop,
+      flush: noop,
+      track: noop,
+      trackAvailability: noop,
+      trackDependency: noop,
+      trackEvent: noop,
+      trackException: noop,
+      trackMetric: noop,
+      trackNodeHttpDependency: noop,
+      trackNodeHttpRequest: noop,
+      trackNodeHttpRequestSync: noop,
+      trackPageView: noop,
+      trackRequest: noop,
+      trackTrace: noop
+    };

--- a/src/appinsights.ts
+++ b/src/appinsights.ts
@@ -2,6 +2,7 @@ import * as appInsights from "applicationinsights";
 import { DistributedTracingModes } from "applicationinsights";
 // tslint:disable-next-line: no-submodule-imports
 import Config = require("applicationinsights/out/Library/Config");
+import { constVoid } from "fp-ts/lib/function";
 import {
   getKeepAliveAgentOptions,
   isFetchKeepaliveEnabled,
@@ -189,7 +190,7 @@ export const defaultClient: typeof appInsights.defaultClient = appInsights.defau
           ];
           return (objectProps as readonly string[]).includes(name)
             ? {}
-            : () => void 0;
+            : () => constVoid;
         }
       }
     ) as typeof appInsights.defaultClient);

--- a/src/appinsights.ts
+++ b/src/appinsights.ts
@@ -178,7 +178,6 @@ export const defaultClient: typeof appInsights.defaultClient = appInsights.defau
   : (new Proxy(
       {},
       {
-        // tslint:disable-next-line: no-any
         // tslint:disable-next-line: typedef
         get(_, name: string) {
           const objectProps: ReadonlyArray<keyof typeof appInsights.defaultClient> = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,15 +565,15 @@ append-transform@^0.4.0:
   dependencies:
     default-require-extensions "^1.0.0"
 
-applicationinsights@^1.7.4:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.7.4.tgz#e7d96435594d893b00cf49f70a5927105dbb8749"
-  integrity sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==
+applicationinsights@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.8.0.tgz#c4c54f7ab420cf97fc07eab2e6e037b5f2158eae"
+  integrity sha512-XgGnuSJrxmfxdqpaJ3XD02Qd1gr7oOpfsijH7y1c9WNag4m7hJq5TUpAYHsJXUOCruaV7H8xNyTrXo82YKlsBQ==
   dependencies:
     cls-hooked "^4.2.2"
     continuation-local-storage "^3.2.1"
-    diagnostic-channel "0.2.0"
-    diagnostic-channel-publishers "^0.3.3"
+    diagnostic-channel "0.3.1"
+    diagnostic-channel-publishers "0.4.0"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1730,15 +1730,15 @@ detect-repo-changelog@1.0.1:
     lodash.find "^4.6.0"
     pify "^2.3.0"
 
-diagnostic-channel-publishers@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.3.tgz#376b7798f4fa90f37eb4f94d2caca611b0e9c330"
-  integrity sha512-qIocRYU5TrGUkBlDDxaziAK1+squ8Yf2Ls4HldL3xxb/jzmWO2Enux7CvevNKYmF2kDXZ9HiRqwjPsjk8L+i2Q==
+diagnostic-channel-publishers@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.0.tgz#254e3bab1dc9021db8aba3efbaefeabf10b84a77"
+  integrity sha512-f6LtD+qukpsjKfckvb0LbYdnCTiiDY3s9ahEH7fInvwq/n6FtoB+HqCB0wR+emZmA/+vwzK0XRe2k1c4gEPmyg==
 
-diagnostic-channel@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz#cc99af9612c23fb1fff13612c72f2cbfaa8d5a17"
-  integrity sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=
+diagnostic-channel@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz#7faa143e107f861be3046539eb4908faab3f53fd"
+  integrity sha512-6eb9YRrimz8oTr5+JDzGmSYnXy5V7YnK5y/hd8AUDK1MssHjQKm9LlD6NSrHx4vMDF3+e/spI2hmWTviElgWZA==
   dependencies:
     semver "^5.3.0"
 


### PR DESCRIPTION
### Motivation
ApplicationInsights' `defaultClient` is instantiated as a singleton inside its module. If no env configuration is provided, this results to be undefined and forces user to check every time before using it.

### Implementation
In case is not defined, we provide a dummy clone in which its methods results in no-operations, avoiding unhandled exceptions.
