### PR TITLE
[#175952695] Add custom TelemetryProcessor to disable sampling (AI)

### DIFF
--- a/src/__tests__/appinsights.test.ts
+++ b/src/__tests__/appinsights.test.ts
@@ -1,6 +1,10 @@
 import * as appInsights from "applicationinsights";
 import { Configuration } from "applicationinsights";
-import { initAppInsights, removeQueryParamsPreprocessor } from "../appinsights";
+import {
+  disableSamplingByTag,
+  initAppInsights,
+  removeQueryParamsPreprocessor
+} from "../appinsights";
 
 describe("Create an App Insights Telemetry Client", () => {
   const mockSetup = jest.spyOn(appInsights, "setup");
@@ -90,5 +94,43 @@ describe("Custom Telemetry Preprocessor", () => {
       (testValidEnvelope as unknown) as appInsights.Contracts.Envelope
     );
     expect(testValidEnvelope.data.baseData.url).toEqual(expectedUrl);
+  });
+});
+
+describe("Disable sampling with custom Telemetry Preprocessor", () => {
+  it("should override sampleRate (defined in ai config) with 100", () => {
+    const expectedSampleRate = 100;
+    const testValidEnvelope: appInsights.Contracts.Envelope = {
+      data: {
+        baseType: "RequestData"
+      },
+      iKey: "key",
+      name: "GET /test",
+      sampleRate: 20,
+      seq: "1",
+      tags: { samplingEnabled: "false" },
+      time: "",
+      ver: 1
+    };
+    disableSamplingByTag(testValidEnvelope);
+    expect(testValidEnvelope.sampleRate).toEqual(expectedSampleRate);
+  });
+
+  it("should NOT override sampleRate", () => {
+    const expectedSampleRate = 20;
+    const testValidEnvelope: appInsights.Contracts.Envelope = {
+      data: {
+        baseType: "RequestData"
+      },
+      iKey: "key",
+      name: "GET /test",
+      sampleRate: 20,
+      seq: "1",
+      tags: { test: "test" },
+      time: "",
+      ver: 1
+    };
+    disableSamplingByTag(testValidEnvelope);
+    expect(testValidEnvelope.sampleRate).toEqual(expectedSampleRate);
   });
 });

--- a/src/appinsights.ts
+++ b/src/appinsights.ts
@@ -69,6 +69,8 @@ function startAppInsights(
     removeQueryParamsPreprocessor
   );
 
+  appInsights.defaultClient.addTelemetryProcessor(disableSamplingByTag);
+
   // Configure the data context of the telemetry client
   // refering to the current application version with a specific CloudRole
 
@@ -118,6 +120,19 @@ export function removeQueryParamsPreprocessor(
     (envelope.data as IInsightsRequestData).baseData.url = originalUrl.split(
       "?"
     )[0];
+  }
+  return true;
+}
+
+export function disableSamplingByTag(
+  envelope: appInsights.Contracts.Envelope,
+  _?: {
+    [name: string]: unknown;
+  }
+): boolean {
+  if (envelope.tags.samplingEnabled === "false") {
+    // tslint:disable-next-line: no-object-mutation
+    envelope.sampleRate = 100;
   }
   return true;
 }


### PR DESCRIPTION
### Description

The PR adds a custom _TelemetryProcessor_ to disable the sampling of given custom events that have the _samplingEnabled_ tag equal to _"false"_.

For example, given the following `Envelope` (applicationinsights.Contracts.Envelope):

```json
    {
      "data": {
        "baseType": "RequestData"
      },
      "iKey": "key",
      "name": "GET /test",
      "sampleRate": 20,
      "seq": "1",
      "tags": { "samplingEnabled": "false" },
      "time": "",
      "ver": 1
    }
```

the custom _TelemetryProcessor_ overwrites _sampleRate_:

```json
    {
      "data": {
        "baseType": "RequestData"
      },
      "iKey": "key",
      "name": "GET /test",
      "sampleRate": 100,
      "seq": "1",
      "tags": { "samplingEnabled": "false" },
      "time": "",
      "ver": 1
    }
```

### Usage

When you want to disable sampling for a custom event, you need to add _samplingEnabled_ tag, for example:

```ts
telemetryClient.trackEvent({
        name: "api.messages.create",
        properties: {
          error: isSuccess ? undefined : r.kind,
          hasDefaultEmail: Boolean(
            messagePayload.default_addresses &&
              messagePayload.default_addresses.email
          ).toString(),
          senderServiceId: serviceId,
          senderUserId: auth.userId,
          success: isSuccess ? "true" : "false"
        },
        tagOverrides: { samplingEnabled: "false" }
      })
```

