### PR TITLE
[#176030906] Add option to use dns.resolve on http clients

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,5 +1,46 @@
 import * as agentkeepalive from "agentkeepalive";
+import * as dns from "dns";
+import { Agent as HttpAgent } from "http";
+import { Agent as HttpsAgent } from "https";
 import nodeFetch from "node-fetch";
+
+// override the host resolution mechanism of an agent to use dns.resolve instead of dns.lookup
+function overrideDnsLookup<
+  // tslint:disable-next-line: max-union-size
+  A extends agentkeepalive | agentkeepalive.HttpsAgent | HttpAgent | HttpsAgent
+>(agent: A): A {
+  // wraps dns.resolve to use a signature like dns.lookup
+  const lookupToResolveAdapter = (
+    hostname: string,
+    _: 4 | 6 | object,
+    cb: (
+      err: NodeJS.ErrnoException | null,
+      resolved?: string,
+      arg2?: number
+    ) => void
+  ) =>
+    dns.resolve(hostname, (err, ips) => (err ? cb(err) : cb(null, ips[0], 4)));
+
+  // @ts-ignore createConnection is a public method of both http.Agent and https.Agent, but it's not defined in their type declaration files
+  const oldCreateConnection = agent.createConnection;
+  // @ts-ignore createConnection is a public method of both http.Agent and https.Agent, but it's not defined in their type declaration files
+  // tslint:disable-next-line: typedef
+  const createConnection = (options, cb): void => {
+    return oldCreateConnection.call(
+      agent,
+      { ...options, lookup: lookupToResolveAdapter },
+      cb
+    );
+  };
+  // @ts-ignore createConnection is a public method of both http.Agent and https.Agent, but it's not defined in their type declaration files
+  // tslint:disable-next-line: no-object-mutation
+  agent.createConnection = createConnection;
+  return agent;
+}
+
+// whether we want to use dns.resolve instead of dns.lookup for domain resoltion
+export const isDnsOverridden = (env: typeof process.env) =>
+  env.FETCH_USE_DNS_RESOLVE === "true";
 
 // whether we want to reuse sockets in the fetch client
 // this is expecially useful to avoid SNAT exhaustion in Azure
@@ -47,47 +88,19 @@ export const newHttpAgent = (httpOptions: agentkeepalive.HttpOptions) =>
 export const newHttpsAgent = (httpsOptions: agentkeepalive.HttpsOptions) =>
   new agentkeepalive.HttpsAgent(httpsOptions);
 
-// Returns a fetch instance backed by a keepalive-enabled HTTP agent
-const getKeepaliveHttpFetch: (
-  _: agentkeepalive.HttpOptions
-) => typeof fetch = httpOptions => {
-  // custom HTTP agent that will reuse sockets
-  // see https://github.com/node-modules/agentkeepalive#new-agentoptions
-  const httpAgent = newHttpAgent(httpOptions);
-
-  return (input, init) => {
-    const initWithKeepalive = {
-      ...(init === undefined ? {} : init),
-      agent: httpAgent
-    };
-    // need to cast to any since node-fetch has a slightly different type
-    // signature that DOM's fetch
-    // TODO: possibly avoid using DOM's fetch type altoghether?
-    // tslint:disable-next-line: no-any
-    return nodeFetch(input as any, initWithKeepalive as any) as any;
+// apply a custom agent to a given htto client instance
+const withCustomAgent = (customAgent?: HttpAgent | HttpsAgent) => (
+  fetchApi: typeof nodeFetch
+): typeof fetch => (input, init) => {
+  const initWithKeepalive = {
+    ...(init === undefined ? {} : init),
+    agent: customAgent
   };
-};
-
-// Returns a fetch instance backed by a keepalive-enabled HTTP agent
-const getKeepaliveHttpsFetch: (
-  _: agentkeepalive.HttpsOptions
-) => typeof fetch = httpsOptions => {
-  // custom HTTP agent that will reuse sockets
-  // see https://github.com/node-modules/agentkeepalive#new-agentoptions
-  const httpAgent = newHttpsAgent(httpsOptions);
-
-  // tslint:disable-next-line: no-identical-functions
-  return (input, init) => {
-    const initWithKeepalive = {
-      ...(init === undefined ? {} : init),
-      agent: httpAgent
-    };
-    // need to cast to any since node-fetch has a slightly different type
-    // signature that DOM's fetch
-    // TODO: possibly avoid using DOM's fetch type altoghether?
-    // tslint:disable-next-line: no-any
-    return nodeFetch(input as any, initWithKeepalive as any) as any;
-  };
+  // need to cast to any since node-fetch has a slightly different type
+  // signature that DOM's fetch
+  // TODO: possibly avoid using DOM's fetch type altoghether?
+  // tslint:disable-next-line: no-any
+  return fetchApi(input as any, initWithKeepalive as any) as any;
 };
 
 // HTTP-only fetch, with optional keepalive agent
@@ -95,25 +108,33 @@ const getKeepaliveHttpsFetch: (
 export const getHttpFetch = (
   env: typeof process.env,
   extraOptions: agentkeepalive.HttpOptions = {}
-): typeof fetch =>
-  isFetchKeepaliveEnabled(env)
-    ? getKeepaliveHttpFetch({
+): typeof fetch => {
+  const withKeepaliveOrDefault = isFetchKeepaliveEnabled(env)
+    ? newHttpAgent({
         ...getKeepAliveAgentOptions(env),
         ...extraOptions
       })
-    : // tslint:disable-next-line: no-any
-      (nodeFetch as any);
+    : undefined;
+  const customAgent = isDnsOverridden(env)
+    ? overrideDnsLookup(withKeepaliveOrDefault || new HttpAgent())
+    : withKeepaliveOrDefault;
+  return withCustomAgent(customAgent)(nodeFetch);
+};
 
 // HTTPs-only fetch, with optional keepalive agent
 // Note: extra options are valid only when FETCH_KEEPALIVE_ENABLED=true
 export const getHttpsFetch = (
   env: typeof process.env,
   extraOptions: agentkeepalive.HttpsOptions = {}
-): typeof fetch =>
-  isFetchKeepaliveEnabled(env)
-    ? getKeepaliveHttpsFetch({
+): typeof fetch => {
+  const withKeepaliveOrDefault = isFetchKeepaliveEnabled(env)
+    ? newHttpsAgent({
         ...getKeepAliveAgentOptions(env),
         ...extraOptions
       })
-    : // tslint:disable-next-line: no-any
-      (nodeFetch as any);
+    : undefined;
+  const customAgent = isDnsOverridden(env)
+    ? overrideDnsLookup(withKeepaliveOrDefault || new HttpsAgent())
+    : withKeepaliveOrDefault;
+  return withCustomAgent(customAgent)(nodeFetch);
+};


### PR DESCRIPTION
Add an option to both `getHttpFetch` and `getHttpsFetch` to override the default mechanism for domain resolution (which is `dns.lookup`) and use `dns.resolve` instead.

### Rationale
`dns.lookup` makes a first attempt to resolve a domain by looking into the local `/etc/hosts` file, determining a file read and consequently a I/O operation to be executed in the node thread pool. When many outbound http requests are performed at the same time, the thread pool migh saturate causing requests to enqueue and the application response time to degrade exponentially.
On the other hand, `dns.resolve` relies only on system's dns primitives and hence is executed in the main thread, which is governed by the event loop mechanism. 

### Usage
Just provide a `FETCH_USE_DNS_RESOLVE="true"` option to either `getHttpFetch` or `getHttpsFetch` smart constructor.

### When to use
Rule of thumb: preferably always if the service doesn't rely on local `hosts` file for name resolving. This might the case of local development or the application running in a container linking to other containers through virtual hosts (example: a `docker-compose` context)

### References
* https://nodejs.org/docs/latest/api/dns.html#dns_implementation_considerations
