### PR TITLE
[#175848172] Added retryLogicForTransientResponseError and Related test

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -2,8 +2,9 @@
  * Helpers for dealing with fetch requests
  */
 
-import { TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
+import { TaskEither, tryCatch, fromEither } from "fp-ts/lib/TaskEither";
 import { timeoutPromise } from "./promises";
+import { left, right } from 'fp-ts/lib/Either';
 import {
   MaxRetries,
   RetriableTask,
@@ -138,3 +139,26 @@ export const retriableFetch: (
     }, reject);
   });
 };
+
+
+/**
+ * Logic for with transient error handling. Handle error that occurs once or at unpredictable intervals. 
+ * @param p 
+ * @param retryLogic 
+ */
+
+export function retryLogicForTransientResponseError(
+  p: (r: Response) => boolean,
+  retryLogic: (
+    t: RetriableTask<Error, Response>,
+    shouldAbort?: Promise<boolean>,
+  ) => TaskEither<Error | 'max-retries' | 'retry-aborted', Response>,
+): typeof retryLogic {
+  return (t: RetriableTask<Error, Response>, shouldAbort?: Promise<boolean>) =>
+    retryLogic(
+      // when the result of the task is a Response that satisfies
+      // the predicate p, map it to a transient error
+      t.chain((r: any) => fromEither(p(r) ? left<TransientError, never>(TransientError) : right<never, Response>(r))),
+      shouldAbort,
+    );
+}


### PR DESCRIPTION
**Description**
This PR adds a function to handle transient errors on fetch response.

**Proposed Changes**
- Added function `retryLogicForTransientResponseError` in `fetch.ts` module
- Added related test

**Test**
`yarn test fetch`