### PR TITLE
[#ENTE-74] new readonlyNonEmptySetType

### DIFF
--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -32,14 +32,13 @@ describe("enumType", () => {
 describe("readonlySetType", () => {
   const aSetOfStrings = readonlySetType(t.string, "Set of strings");
 
-  it("should validate", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const fixtures: ReadonlyArray<any> = [[], ["a"], new Set("x")];
-
-    fixtures.forEach(f => {
+  it.each
+  `title | f
+  ${"an empty array"} | ${[]}
+  ${"a not empty array"} | ${["a", "b"]}
+  ${"a non empty set"} | ${new Set("x")}`("should validate $title", ({f}) => {
       const v = aSetOfStrings.decode(f);
       expect(v.isRight()).toBeTruthy();
-    });
   });
 });
 
@@ -49,15 +48,14 @@ describe("readonlyNonEmptySetType", () => {
     "Set of strings"
   );
 
-  it("should not validate if is an empty set", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const fixtures: ReadonlyArray<any> = [[], new Set()];
-
-    fixtures.forEach(f => {
+  it.each
+    `title | f
+    ${"an empty set array"} | ${new Set()}
+    ${"an empty array"} | ${[]}`
+  ("should not validate if is $title", ({f}) => {
       const v = aReadonlyNonEmptySet.decode(f);
       expect(v.isLeft()).toBeTruthy();
       expect(aReadonlyNonEmptySet.is(f)).toBeFalsy();
-    });
   });
 
   it("should create immutable set from an array", () => {
@@ -84,17 +82,15 @@ describe("readonlyNonEmptySetType", () => {
       expect(maybeFromSet.value.has(anUnexpectedValue)).toBe(false);
     }
   });
-
-  it("should validate", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const fixtures: ReadonlyArray<any> = [["a"], ["a", "b"], new Set("x")];
-
-    fixtures.forEach(f => {
+  it.each
+    `title | f
+    ${"a one element array"} | ${["a"]}
+    ${"a two element array"} | ${["a", "b"]}
+    ${"a non empty set"} | ${new Set("x")}`("should validate $title", ({f}) => {
       const v = aReadonlyNonEmptySet.decode(f);
       expect(v.isRight()).toBeTruthy();
       // We use the decoded value where Array are trasformed to Set
       expect(aReadonlyNonEmptySet.is(v.value)).toBeTruthy();
-    });
   });
 });
 

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -1,11 +1,12 @@
 import * as t from "io-ts";
 
-import { strictInterfaceWithOptionals, withoutUndefinedValues } from "../types";
+import { readonlyNonEmptySetType, strictInterfaceWithOptionals, withoutUndefinedValues } from "../types";
 
 import { isLeft, isRight } from "fp-ts/lib/Either";
 import { readableReport } from "../reporters";
 
 import { enumType, readonlySetType, withDefault } from "../types";
+import SerializableSet from "json-set-map/build/src/set";
 
 enum aValidEnum {
   "foo" = "fooValue",
@@ -35,6 +36,33 @@ describe("readonlySetType", () => {
     fixtures.forEach(f => {
       const v = aSetOfStrings.decode(f);
       expect(v.isRight()).toBeTruthy();
+    });
+  });
+});
+
+describe("readonlyNonEmptySetType", () => {
+  const aReadonlyNonEmptySet = readonlyNonEmptySetType(t.string, "Set of strings");
+
+  it("should not validate if is an empty set", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fixtures: ReadonlyArray<any> = [[], new Set()];
+
+    fixtures.forEach(f => {
+      const v = aReadonlyNonEmptySet.decode(f);
+      expect(v.isLeft()).toBeTruthy();
+      expect(aReadonlyNonEmptySet.is(f)).toBeFalsy();
+    });
+  });
+
+  it("should validate", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fixtures: ReadonlyArray<any> = [["a"], ["a", "b"], new Set("x")];
+
+    fixtures.forEach(f => {
+      const v = aReadonlyNonEmptySet.decode(f);
+      expect(v.isRight()).toBeTruthy();
+      // We use the decoded value where Array are trasformed to Set
+      expect(aReadonlyNonEmptySet.is(v.value)).toBeTruthy();
     });
   });
 });

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -6,7 +6,6 @@ import { isLeft, isRight } from "fp-ts/lib/Either";
 import { readableReport } from "../reporters";
 
 import { enumType, readonlySetType, withDefault } from "../types";
-import SerializableSet from "json-set-map/build/src/set";
 
 enum aValidEnum {
   "foo" = "fooValue",

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -1,6 +1,10 @@
 import * as t from "io-ts";
 
-import { readonlyNonEmptySetType, strictInterfaceWithOptionals, withoutUndefinedValues } from "../types";
+import {
+  readonlyNonEmptySetType,
+  strictInterfaceWithOptionals,
+  withoutUndefinedValues
+} from "../types";
 
 import { isLeft, isRight } from "fp-ts/lib/Either";
 import { readableReport } from "../reporters";
@@ -40,7 +44,10 @@ describe("readonlySetType", () => {
 });
 
 describe("readonlyNonEmptySetType", () => {
-  const aReadonlyNonEmptySet = readonlyNonEmptySetType(t.string, "Set of strings");
+  const aReadonlyNonEmptySet = readonlyNonEmptySetType(
+    t.string,
+    "Set of strings"
+  );
 
   it("should not validate if is an empty set", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -51,6 +58,31 @@ describe("readonlyNonEmptySetType", () => {
       expect(v.isLeft()).toBeTruthy();
       expect(aReadonlyNonEmptySet.is(f)).toBeFalsy();
     });
+  });
+
+  it("should create immutable set from an array", () => {
+    const anArray = ["a", "b"];
+    const anUnexpectedValue = "foo";
+
+    const maybeFromArray = aReadonlyNonEmptySet.decode(anArray);
+
+    anArray.push(anUnexpectedValue);
+
+    if (maybeFromArray.isRight()) {
+      expect(maybeFromArray.value.has(anUnexpectedValue)).toBe(false);
+    }
+  });
+  it("should create immutable set from a set", () => {
+    const aSet = new Set("x");
+    const anUnexpectedValue = "foo";
+
+    const maybeFromSet = aReadonlyNonEmptySet.decode(aSet);
+
+    aSet.add(anUnexpectedValue);
+
+    if (maybeFromSet.isRight()) {
+      expect(maybeFromSet.value.has(anUnexpectedValue)).toBe(false);
+    }
   });
 
   it("should validate", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,10 +84,10 @@ export const readonlySetType = <E>(
     name,
     (s): s is ReadonlySet<E> => s instanceof Set && arrayType.is(Array.from(s)),
     (s, c) => {
-      if (s instanceof Set && arrayType.is(Array.from(s))) {
-        return t.success(s);
-      }
-      if (arrayType.is(s)) {
+      if (
+        (s instanceof Set && arrayType.is(Array.from(s))) ||
+        arrayType.is(s)
+      ) {
         return t.success(new SerializableSet(Array.from(s)));
       }
       return t.failure(s, c);
@@ -113,7 +113,7 @@ export const readonlyNonEmptySetType = <E>(
       s instanceof Set && arrayType.is(Array.from(s)) && s.size > 0,
     (s, c) => {
       if (s instanceof Set && arrayType.is(Array.from(s)) && s.size > 0) {
-        return t.success(s);
+        return t.success(new SerializableSet(Array.from(s)));
       }
       if (arrayType.is(s) && s.length > 0) {
         return t.success(new SerializableSet(Array.from(s)));

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,34 @@ export const readonlySetType = <E>(
   );
 };
 
+// eslint-disable-next-line @typescript-eslint/naming-convention,@typescript-eslint/no-empty-interface
+export interface ReadOnlyNonEmptySet<T> extends ReadonlySet<T> {}
+
+/**
+ * Creates an io-ts Type from a ReadonlyNonEmptySet
+ */
+export const readonlyNonEmptySetType = <E>(
+  o: t.Type<E, t.mixed>,
+  name: string
+): t.Type<ReadOnlyNonEmptySet<E>, t.mixed> => {
+  const arrayType = t.readonlyArray(o, name);
+  return new t.Type<ReadOnlyNonEmptySet<E>, t.mixed>(
+    name,
+    (s): s is ReadOnlyNonEmptySet<E> =>
+      s instanceof Set && arrayType.is(Array.from(s)) && s.size > 0,
+    (s, c) => {
+      if (s instanceof Set && arrayType.is(Array.from(s)) && s.size > 0) {
+        return t.success(s);
+      }
+      if (arrayType.is(s) && s.length > 0) {
+        return t.success(new SerializableSet(Array.from(s)));
+      }
+      return t.failure(s, c);
+    },
+    t.identity
+  );
+};
+
 /**
  * Returns a new type that has only the F fields of type T.
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,24 +105,8 @@ export interface ReadOnlyNonEmptySet<T> extends ReadonlySet<T> {}
 export const readonlyNonEmptySetType = <E>(
   o: t.Type<E, t.mixed>,
   name: string
-): t.Type<ReadOnlyNonEmptySet<E>, t.mixed> => {
-  const arrayType = t.readonlyArray(o, name);
-  return new t.Type<ReadOnlyNonEmptySet<E>, t.mixed>(
-    name,
-    (s): s is ReadOnlyNonEmptySet<E> =>
-      s instanceof Set && arrayType.is(Array.from(s)) && s.size > 0,
-    (s, c) => {
-      if (s instanceof Set && arrayType.is(Array.from(s)) && s.size > 0) {
-        return t.success(new SerializableSet(Array.from(s)));
-      }
-      if (arrayType.is(s) && s.length > 0) {
-        return t.success(new SerializableSet(Array.from(s)));
-      }
-      return t.failure(s, c);
-    },
-    t.identity
-  );
-};
+): t.Type<ReadOnlyNonEmptySet<E>, t.mixed> =>
+  t.refinement(readonlySetType(o, name), e => e.size > 0, name);
 
 /**
  * Returns a new type that has only the F fields of type T.


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
new `readonlyNonEmptySetType` defined
Unit test for `readonlyNonEmptySetType` decoder
#### Motivation and Context
Costom decoder for `readonlyNonEmptySetType` usable into `Service` model to verify non-empty `authorizedCIDRs` ([link](https://github.com/pagopa/io-functions-commons/blob/master/src/models/service.ts#L76)).

#### How Has This Been Tested?
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
