### PR TITLE
Add Fetch with Processor

### DIFF
--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -1,6 +1,7 @@
 import * as t from "io-ts";
 import * as E from "fp-ts/lib/Either";
 import {
+  filterValues,
   readonlyNonEmptySetType,
   strictInterfaceWithOptionals,
   withoutUndefinedValues
@@ -109,7 +110,7 @@ describe("definedValues", () => {
       }
     };
 
-    const newObj = withoutUndefinedValues(obj);
+    const newObj = withoutUndefinedValues(obj) as any;
 
     expect(Object.keys(newObj).length).toEqual(2);
     expect(Object.keys(newObj.c).length).toEqual(1);
@@ -118,6 +119,42 @@ describe("definedValues", () => {
       a: 1,
       c: {
         d: [1, 2]
+      }
+    });
+  });
+});
+
+describe("filteredValues", () => {
+  it("should filter properties recursively given a process function", async () => {
+    const obj = {
+      a: 1,
+      b: undefined,
+      c: {
+        d: [1, 2],
+        e: undefined,
+        f: null,
+        g: {
+          h: "",
+          i: 2
+        }
+      }
+    };
+
+    const newObj = filterValues(_ => _ !== "" && _ !== null)(obj);
+
+    expect(Object.keys(newObj).length).toEqual(3);
+    expect(Object.keys(newObj.c).length).toEqual(3);
+    expect(Object.keys(newObj.c.g).length).toEqual(1);
+
+    expect(newObj).toEqual({
+      a: 1,
+      b: undefined,
+      c: {
+        d: [1, 2],
+        e: undefined,
+        g: {
+          i: 2
+        }
       }
     });
   });

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -144,3 +144,24 @@ export const retriableFetch: (
     }, reject);
   });
 };
+
+/**
+ * Makes fetch able to process response with a given processor function
+ *
+ * @param processor: a function that applies to original response
+ * @returns: a new fetch with processor capabilities
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const fetchWithProcessor = (processor: (a: any) => any) => (
+  f: typeof fetch
+): typeof fetch => async (input, init): Promise<Response> => {
+  const old = await f(input, init);
+  return {
+    ...old,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    json: async (): Promise<any> => {
+      const original = await old.json();
+      return processor(original);
+    }
+  };
+};


### PR DESCRIPTION
This PR adds a new kind of fetch wrapper that allows to manipulate json response by giving a processor function.
Other changes:
- add `RecursiveRecord` type in order to map a general json type, thanks to @balanza
- add `filterValues` utility function
- refactor of `withoutUndefinedValues` utility function