### PR TITLE
[Proposal] New request middleware implementation

### DIFF
--- a/src/__tests__/request_middleware_2v.test.ts
+++ b/src/__tests__/request_middleware_2v.test.ts
@@ -1,0 +1,121 @@
+// eslint-disable @typescript-eslint/no-explicit-any
+
+import {
+  IRequestMiddleware,
+  withRequestMiddlewaresStruct
+} from "../request_middleware_2v";
+import {
+  IResponse,
+  IResponseErrorValidation,
+  ResponseErrorValidation
+} from "../responses";
+
+import { left, right } from "fp-ts/lib/Either";
+import { string } from "fp-ts";
+
+const ResolvingMiddleware: IRequestMiddleware<never, string> = req => {
+  return Promise.resolve(right<never, string>(req.params.dummy));
+};
+
+const RejectingMiddleware: IRequestMiddleware<
+  "IResponseErrorValidation",
+  string
+> = _ => {
+  return Promise.resolve(
+    left<IResponseErrorValidation, string>(
+      ResponseErrorValidation("NOK", "NOT")
+    )
+  );
+};
+
+const request = {
+  params: {
+    dummy: "dummy"
+  }
+};
+
+const response = {} as IResponse<{}>;
+
+describe("withRequestMiddlewares", () => {
+  it("should allow up to 7 middlewares", () => {
+    expect(withRequestMiddlewaresStruct.length).toBe(7);
+  });
+
+  // one case for any number of supported middlewares
+  const cases = [1, 2, 3, 10];
+  it.each(cases)(
+    "should process a request with %i resolving middlewares",
+    n => {
+      const mockHandler = jest.fn(() => Promise.resolve(response));
+
+      const middlewares = [...Array(n).keys()].reduce((prev, curr, i) => {
+        prev["middleware_" + i] = ResolvingMiddleware;
+        return prev;
+      }, {} as Record<string, any>);
+      const expected = [...Array(n).keys()].reduce((prev, curr, i) => {
+        prev["middleware_" + i] = "dummy";
+        return prev;
+      }, {} as Record<string, string>);
+
+      // @ts-ignore because withRequestMiddlewares complaints about middlewares could be any size
+      const handler = withRequestMiddlewaresStruct(middlewares)(mockHandler);
+
+      console.log(expected);
+
+      return handler(request as any).then((r: any) => {
+        expect(mockHandler).toHaveBeenCalledWith(expected);
+        expect(r).toEqual(response);
+      });
+    }
+  );
+
+  it.each(cases)(
+    "should process a request with %i middlewares whose last one rejects",
+
+    n => {
+      const mockHandler = jest.fn(() => Promise.resolve(response));
+
+      // Provide a series of resolving middlewares followed by a rejecting one
+      //   by providing the rejecting middleware at last, we ensure it's actually executed and its result matters
+      const middlewares = [...Array(n).keys()].reduce((prev, _, i) => {
+        prev["middleware_" + i] =
+          i < n - 1 ? ResolvingMiddleware : RejectingMiddleware;
+        return prev;
+      }, {} as Record<string, any>);
+
+      // @ts-ignore because withRequestMiddlewares complaints about middlewares could be any size
+      const handler = withRequestMiddlewaresStruct(middlewares)(mockHandler);
+
+      return handler(request as any).then((r: any) => {
+        expect(mockHandler).not.toHaveBeenCalled();
+        expect(r.kind).toBe("IResponseErrorValidation");
+      });
+    }
+  );
+
+  it("should process a request with a rejecting middleware", () => {
+    const mockHandler = jest.fn(({ reject }) => Promise.resolve(response));
+
+    const handler = withRequestMiddlewaresStruct({
+      reject: RejectingMiddleware
+    })(mockHandler);
+
+    return handler(request as any).then(r => {
+      expect(mockHandler).not.toHaveBeenCalled();
+      expect(r.kind).toBe("IResponseErrorValidation");
+    });
+  });
+
+  it("should stop processing middlewares after a rejecting middleware", () => {
+    const mockHandler = jest.fn(() => Promise.resolve(response));
+    const handler = withRequestMiddlewaresStruct({
+      reject: RejectingMiddleware,
+      resolve: ResolvingMiddleware
+    })(mockHandler);
+
+    return handler(request as any).then(r => {
+      expect(mockHandler).not.toHaveBeenCalled();
+      expect(r.kind).toBe("IResponseErrorValidation");
+    });
+  });
+});

--- a/src/request_middleware_2v.ts
+++ b/src/request_middleware_2v.ts
@@ -1,0 +1,196 @@
+import * as express from "express";
+
+import * as E from "fp-ts/lib/Either";
+import * as TE from "fp-ts/lib/TaskEither";
+
+import { sequenceS } from "fp-ts/lib/Apply";
+
+import { pipe } from "fp-ts/lib/function";
+import { IResponse, ResponseErrorInternal } from "./responses";
+
+export type EnforceNonEmptyRecord<R> = keyof R extends never ? never : R;
+
+export type RequestHandler<R> = (
+  request: express.Request
+) => Promise<IResponse<R>>;
+
+/**
+ * Request handler type
+ */
+type IRequestHandler<Params, Return> = (
+  args: Params
+) => Promise<IResponse<Return>>;
+
+/**
+ * Interface for implementing a request middleware.
+ *
+ * A RequestMiddleware is just a function that validates a request or
+ * extracts some object out of it.
+ * The middleware returns a promise that will resolve to a value that gets
+ * passed to the handler.
+ * In case the validation fails, the middleware rejects the promise (the
+ * value of the error is discarded). In this case the processing of the
+ * following middlewares will not happen.
+ * Finally, when called, the middleware has full access to the request and
+ * the response objects. Access to the response object is particulary useful
+ * for returning error messages when the validation fails.
+ */
+export type IRequestMiddleware<R, T> = (
+  request: express.Request
+) => Promise<E.Either<IResponse<R>, T>>;
+
+/**
+ * A typed map containing all the middlewares needed by the request.
+ * `Params` defines a Record containing all the values names to be returned.
+ *
+ * @example
+ * {
+ *  context: ContextMiddleware(),
+ *  fiscalCode: FiscalCodeMiddleware()
+ * }
+ */
+export type IRequestMiddlewares<Params> = {
+  [key in keyof Params]: IRequestMiddleware<unknown, Params[key]>;
+};
+
+type MiddlewaresTaskEithers<
+  MiddlewareStruct extends IRequestMiddlewares<unknown>
+> = {
+  readonly [key in keyof MiddlewareStruct]: MiddlewareStruct[key] extends IRequestMiddleware<
+    unknown,
+    infer T
+  >
+    ? TE.TaskEither<AllMiddlewaresFailureResults<MiddlewareStruct>, T>
+    : never;
+};
+
+export type ParamsUnion<OBJ> = OBJ[keyof OBJ];
+
+// ----- Middlewares  Failure Result Types
+
+export type MiddlewareFailureResult<T> = T extends IRequestMiddleware<
+  infer R,
+  unknown
+>
+  ? R extends IResponse<infer Res>
+    ? Res
+    : R
+  : never;
+
+export type MiddlewaresFailureResults<
+  M extends IRequestMiddlewares<unknown>
+> = {
+  readonly [k in keyof M]: MiddlewareFailureResult<M[k]>;
+};
+
+export type AllMiddlewaresFailureResults<
+  M extends IRequestMiddlewares<unknown>
+> = ParamsUnion<MiddlewaresFailureResults<M>>;
+
+// ----- Middlewares Result Types
+
+export type MiddlewareResult<T> = T extends IRequestMiddleware<unknown, infer R>
+  ? R
+  : never;
+export type MiddlewaresResults<M extends IRequestMiddlewares<unknown>> = {
+  readonly [k in keyof M]: MiddlewareResult<M[k]>;
+};
+export type AllMiddlewaresResults<
+  M extends IRequestMiddlewares<unknown>
+> = ParamsUnion<MiddlewaresResults<M>>;
+
+/**
+ * Builds a record of TaskEither from a record of IRequestMiddleware promise
+ * @param middlewares the record containing all the Middlewares to process
+ * @returns a function that takes an express.Request and returns a TaskEither
+ * contaiing either one of the Middlerwares' errors or a structure with Middlewares' results
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getMiddlewaresTaskEithers = <K extends IRequestMiddlewares<any>>(
+  middlewares: K
+) => (req: express.Request): EnforceNonEmptyRecord<MiddlewaresTaskEithers<K>> =>
+  Object.keys(middlewares).reduce(
+    (prev, name) => ({
+      ...prev,
+      [name]: pipe(
+        TE.tryCatch(
+          async () => await middlewares[name](req),
+          _ => ResponseErrorInternal(`error executing middleware ${name}`)
+        ),
+        TE.chain(TE.fromEither)
+      )
+    }),
+    {}
+  ) as EnforceNonEmptyRecord<MiddlewaresTaskEithers<K>>;
+
+/**
+ * Wraps a request handler with a record of Middlewares.
+ * If all Middlewares returns the right value, the handler will be called
+ * with the resulting record of values.
+ * @param middlewares The record containing the middlewares to call
+ * @returns a promise containing the handler responce or a Middleware's failure result.
+ */
+export const withRequestMiddlewaresStruct = <Params>(
+  middlewares: IRequestMiddlewares<Params>
+) => <RH>(
+  handler: IRequestHandler<MiddlewaresResults<typeof middlewares>, RH>
+): RequestHandler<
+  | RH
+  | "IResponseErrorInternal"
+  | AllMiddlewaresFailureResults<typeof middlewares>
+> => async (
+  request: express.Request
+): Promise<
+  IResponse<
+    | RH
+    | "IResponseErrorInternal"
+    | AllMiddlewaresFailureResults<typeof middlewares>
+  >
+> => {
+  type Failures = AllMiddlewaresFailureResults<typeof middlewares>;
+  type StructResult = MiddlewaresResults<typeof middlewares>;
+
+  if (Object.keys(middlewares).length > 0) {
+    return pipe(
+      request,
+      getMiddlewaresTaskEithers(middlewares),
+      val =>
+        sequenceS(TE.ApplicativePar)(val) as TE.TaskEither<
+          Failures,
+          StructResult
+        >,
+      TE.chainW(params =>
+        pipe(
+          TE.tryCatch(() => handler(params), E.toError),
+          TE.mapLeft(err =>
+            ResponseErrorInternal(
+              `Error executing endpoint handler: ${err.message}`
+            )
+          )
+        )
+      ),
+      TE.toUnion
+    )() as Promise<IResponse<RH | Failures | "IResponseErrorInternal">>;
+  } else {
+    return handler({} as StructResult);
+  }
+};
+
+/**
+ * Transforms a typesafe RequestHandler into an Express Request Handler.
+ *
+ * Failed promises will be mapped to 500 errors handled by ResponseErrorGeneric.
+ */
+export const wrapRequestHandler = <R>(handler: RequestHandler<R>) => (
+  request: express.Request,
+  response: express.Response,
+  _: express.NextFunction
+): Promise<void> =>
+  handler(request).then(
+    r => {
+      r.apply(response);
+    },
+    e => {
+      ResponseErrorInternal(e).apply(response);
+    }
+  );


### PR DESCRIPTION
A proposal for adding a new request middlewares implementation, free of middlewares number restriction.

It allows to process a list of middlewares and pass their results to the handler as a structure.

Usage:

``` typescript

const middlewares = 
{
  param1: Middleware1,
  param2: Middleware2,
  param3 Middleware3,
  param4: Middleware4
};

  const handlerWithComputedValues = withRequestMiddlewares(middlewares)(handler);

```

where `handler` expects a struct containing param1,.., param4 parameters.