### PR TITLE
Hotfix: Added booleans from string type

### DIFF
--- a/src/__tests__/booleans.test.ts
+++ b/src/__tests__/booleans.test.ts
@@ -1,0 +1,29 @@
+/* eslint-disable sonarjs/no-identical-functions */
+
+import { isLeft, isRight } from "fp-ts/lib/Either";
+import {
+  BooleanFromString
+} from "../booleans";
+
+describe("BooleanFromString", () => {
+    it("should get boolean true from string 'true'", async () => {
+      const n = BooleanFromString.decode("true");
+      expect(isRight(n)).toBeTruthy();
+      if (isRight(n)) {
+        expect(n.value).toEqual(true);
+      }
+    });
+
+    it("should get boolean false from string 'false'", async () => {
+      const n = BooleanFromString.decode("false");
+      expect(isRight(n)).toBeTruthy();
+      if (isRight(n)) {
+        expect(n.value).toEqual(false);
+      }
+    });
+
+    it("should get error from string 'astring'", () => {
+      const n = BooleanFromString.decode("astring");
+      expect(isLeft(n)).toBeTruthy();
+    });
+  });

--- a/src/booleans.ts
+++ b/src/booleans.ts
@@ -1,0 +1,19 @@
+import * as t from "io-ts";
+
+export type BooleanFromString = t.Type<boolean, string, unknown>;
+
+export const BooleanFromString: BooleanFromString = new t.Type<
+  boolean,
+  string,
+  unknown
+>(
+  "BooleanFromString",
+  t.boolean.is,
+  (s, c) =>
+    s === "true"
+      ? t.success(true)
+      : s === "false"
+      ? t.success(false)
+      : t.failure(s, c),
+  String
+);


### PR DESCRIPTION
HOTFIX

This is branched from TAG 9.4.1-Release.

DO NOT MERGE ON MASTER

We need this type to be imported in io-backend to generate correct model for getMessages from query params.