### PR TITLE
[#IC-206] Add ognl io-ts type

### DIFF
--- a/src/__tests__/pngl.test.ts
+++ b/src/__tests__/pngl.test.ts
@@ -1,0 +1,60 @@
+import { set, nestifyPrefixedType, ognlTypeFor } from "../ognl";
+import * as E from "fp-ts/Either";
+import * as t from "io-ts";
+
+const dummyEnv = {
+  OTHERS: "others env properties",
+  PREFIX_id: "dummy_id",
+  PREFIX_name: "dummy_name",
+  PREFIX_inner_id: "dummy_inner_id"
+};
+
+const dummyNestedEnv = {
+  id: "dummy_id",
+  name: "dummy_name",
+  inner: { id: "dummy_inner_id" }
+};
+
+const dummyTypeDecoded = {
+  id: "dummy_id",
+  name: "dummy_name",
+  inner: { id: "dummy_inner_id" }
+};
+
+type dummyType = t.Type<typeof dummyType>;
+const dummyType = t.interface({
+  id: t.string,
+  name: t.string,
+  inner: t.interface({ id: t.string })
+});
+
+describe("set", () => {
+  it(`set a value from string`, async () => {
+    // Demo
+    let obj = {};
+    set(obj, "test.field", "value");
+    expect(obj).toEqual({ test: { field: "value" } });
+  });
+});
+
+describe("ognl", () => {
+  it("GIVEN an env containing also properties in the format PREFIX<field_path> WHEN nestifyPrefixedType is called THEN an object with <field_path> as nested field is returned", () => {
+    const processed = nestifyPrefixedType(dummyEnv, "PREFIX");
+    expect(processed).toStrictEqual(dummyNestedEnv);
+  });
+
+  it("GIVEN a not valid dummyType configuration WHEN the decode is called THEN a left either is returned", () => {
+    const decoded = ognlTypeFor(dummyType, "PREFIX").decode({
+      PREFIX_wrong: "wrong"
+    });
+    expect(E.isLeft(decoded)).toBeTruthy();
+  });
+
+  it("GIVEN a valid dummyType configuration WHEN the ognl decode is called THEN a right either is returned", () => {
+    const decoded = ognlTypeFor(dummyType, "PREFIX").decode(dummyEnv);
+    expect(E.isRight(decoded)).toBeTruthy();
+    if (E.isRight(decoded)) {
+      expect(E.getOrElseW(() => "")(decoded)).toStrictEqual(dummyTypeDecoded);
+    }
+  });
+});

--- a/src/ognl.ts
+++ b/src/ognl.ts
@@ -1,0 +1,109 @@
+import { pipe } from "fp-ts/function";
+import * as R from "fp-ts/Record";
+import * as t from "io-ts";
+import * as E from "fp-ts/Either";
+
+/**
+ * Porting of lodash "set" function.
+ *
+ * @param obj input object
+ * @param path field path
+ * @param value value
+ * @returns the input object with value set in the field pointed by path
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export const set = <T extends object>(
+  obj: T,
+  path: string | ReadonlyArray<string>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: any
+): T => {
+  if (Object(obj) !== obj) {
+    return obj;
+  } // When obj is not an object
+  // If not yet an array, get the keys from the string-path
+  const splittedpath: ReadonlyArray<string> = !Array.isArray(path)
+    ? path.toString().match(/[^.[\]]+/g) || []
+    : path;
+  // eslint-disable-next-line functional/immutable-data
+  splittedpath.slice(0, -1).reduce(
+    (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      a: any,
+      c,
+      _i
+    ) =>
+      // Iterate all of them except the last one
+      Object(a[c]) === a[c]
+        ? a[c]
+        : // eslint-disable-next-line functional/immutable-data
+          (a[c] = {}),
+    obj
+  )[splittedpath[splittedpath.length - 1]] = value;
+  return obj;
+};
+
+/**
+ * This functions create an object containig only the properties starting with 'prefix'. The env properties name will be splited using '_' to create nested object.
+ * eg. TARGETKAFKA_client_id: 1234 => { client: { id: 1234 } }
+ *
+ * @param env the input env
+ * @param prefix the properties prefix
+ * @returns a object
+ */
+export const nestifyPrefixedType = (
+  env: Record<string, unknown>,
+  prefix: string
+): Record<string, unknown> =>
+  pipe(
+    env,
+    R.filterWithIndex(fieldName => fieldName.split("_")[0] === prefix),
+    R.reduceWithIndex({}, (k, b, a) =>
+      set(
+        b,
+        // eslint-disable-next-line functional/immutable-data
+        k
+          .split("_")
+          .splice(1)
+          .join("."),
+        a
+      )
+    )
+  );
+
+const isRecordOfString = (i: unknown): i is Record<string, unknown> =>
+  typeof i === "object" &&
+  i !== null &&
+  !Object.keys(i).some(property => typeof property !== "string");
+
+const createNotRecordOfStringErrorL = (
+  input: unknown,
+  context: t.Context
+) => (): t.Errors => [
+  {
+    context,
+    message: "input is not a valid record of string",
+    value: input
+  }
+];
+
+export const ognlTypeFor = <T>(
+  type: t.Mixed,
+  prefix: string
+): t.Type<T, T, unknown> =>
+  new t.Type<T, T, unknown>(
+    "KafkaProducerCompactConfigFromEnv",
+    (u: unknown): u is T => type.is(u),
+    (input, context) =>
+      pipe(
+        input,
+        E.fromPredicate(
+          isRecordOfString,
+          createNotRecordOfStringErrorL(input, context)
+        ),
+        E.chainW(inputRecord =>
+          type.validate(nestifyPrefixedType(inputRecord, prefix), context)
+        )
+      ),
+    t.identity
+  );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add a OGNL decoder implemented with io-ts in order to populate a complex type from environment variables without manual map between env vars and fields.
This is a freely implementation of Object Graph Navigation library of apache.

#### List of Changes
<!--- Describe your changes in detail -->
Add nestifyPrefixedType function
Add ognl decoder creator function

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently we can not automatically populate an inner object value from an evn var.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
