### PR TITLE
[#IC-418] Add PATCH request type

### DIFF
--- a/src/__tests__/requests.test.ts
+++ b/src/__tests__/requests.test.ts
@@ -6,6 +6,7 @@ import {
   BasicResponseType,
   createFetchRequestForApi,
   IGetApiRequestType,
+  IPatchApiRequestType,
   IPostApiRequestType
 } from "../requests";
 
@@ -70,6 +71,26 @@ const postSimpleT: PostSimpleT = {
     "Content-Type": "application/json"
   }),
   method: "post",
+  query: () => ({}),
+  response_decoder: basicResponseDecoder(SimpleModel),
+  url: () => "/api/v1/simples"
+};
+
+type PatchSimpleT = IPatchApiRequestType<
+  {
+    readonly value: SimpleModel;
+  },
+  never,
+  never,
+  BasicResponseType<SimpleModel>
+>;
+
+const patchSimpleT: PatchSimpleT = {
+  body: params => JSON.stringify(params.value),
+  headers: () => ({
+    "Content-Type": "application/json"
+  }),
+  method: "patch",
   query: () => ({}),
   response_decoder: basicResponseDecoder(SimpleModel),
   url: () => "/api/v1/simples"
@@ -192,6 +213,28 @@ describe("A simple POST API", () => {
       body: JSON.stringify(simpleValue),
       headers: { "Content-Type": "application/json" },
       method: "post"
+    });
+  });
+});
+
+describe("A simple PATCH API", () => {
+  it("should patch the right payload", async () => {
+    const fetchApi = mockFetch(200, simpleValue);
+
+    const patchSimple = createFetchRequestForApi(patchSimpleT, {
+      baseUrl,
+      fetchApi
+    });
+
+    await patchSimple({
+      value: simpleValue
+    });
+
+    expect(fetchApi).toHaveBeenCalledTimes(1);
+    expect(fetchApi).toHaveBeenCalledWith("https://localhost/api/v1/simples", {
+      body: JSON.stringify(simpleValue),
+      headers: { "Content-Type": "application/json" },
+      method: "patch"
     });
   });
 });

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -748,6 +748,8 @@ export type MapResponseType<
   ? IPutApiRequestType<P3, H3, Q3, MapTypeInApiResponse<R3, S, B>>
   : T extends IDeleteApiRequestType<infer P4, infer H4, infer Q4, infer R4>
   ? IDeleteApiRequestType<P4, H4, Q4, MapTypeInApiResponse<R4, S, B>>
+  : T extends IPatchApiRequestType<infer P5, infer H5, infer Q5, infer R5>
+  ? IPatchApiRequestType<P5, H5, Q5, MapTypeInApiResponse<R5, S, B>>
   : never;
 
 /**
@@ -768,7 +770,9 @@ export type RequestParams<T> = T extends IGetApiRequestType<
   : T extends IPutApiRequestType<infer P3, infer _H3, infer _Q3, infer _R3>
   ? P3 // eslint-disable-next-line @typescript-eslint/no-unused-vars
   : T extends IDeleteApiRequestType<infer P4, infer _H4, infer _Q4, infer _R4>
-  ? P4
+  ? P4 // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  : T extends IPatchApiRequestType<infer P5, infer _H5, infer _Q5, infer _R5>
+  ? P5
   : never;
 
 /**
@@ -787,7 +791,9 @@ export type ReplaceRequestParams<T, P> = T extends IGetApiRequestType<
   : T extends IPutApiRequestType<infer _P3, infer H3, infer Q3, infer R3>
   ? IPutApiRequestType<P, H3, Q3, R3> // eslint-disable-next-line @typescript-eslint/no-unused-vars
   : T extends IDeleteApiRequestType<infer _P4, infer H4, infer Q4, infer R4>
-  ? IDeleteApiRequestType<P, H4, Q4, R4>
+  ? IDeleteApiRequestType<P, H4, Q4, R4> // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  : T extends IPatchApiRequestType<infer _P4, infer H5, infer Q5, infer R5>
+  ? IPatchApiRequestType<P, H5, Q5, R5>
   : never;
 
 /**
@@ -805,6 +811,8 @@ export type AddResponseType<
   ? IPutApiRequestType<P3, H3, Q3, R3 | IResponseType<S, A>>
   : T extends IDeleteApiRequestType<infer P4, infer H4, infer Q4, infer R4>
   ? IDeleteApiRequestType<P4, H4, Q4, R4 | IResponseType<S, A>>
+  : T extends IPatchApiRequestType<infer P5, infer H5, infer Q5, infer R5>
+  ? IPatchApiRequestType<P5, H5, Q5, R5 | IResponseType<S, A>>
   : never;
 
 /**

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -192,7 +192,7 @@ export interface IPutApiRequestType<
 /**
  * Fully describes a PATCH request.
  *
- * PUT requests require to provide the "Content-Type" header.
+ * PATCH requests require to provide the "Content-Type" header.
  */
 export interface IPatchApiRequestType<
   P,

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -16,7 +16,7 @@ import { pipe } from "fp-ts/lib/function";
 /**
  * Describes the possible methods of a request
  */
-export type RequestMethod = "get" | "post" | "put" | "delete";
+export type RequestMethod = "get" | "post" | "put" | "delete" | "patch";
 
 /**
  * Describes the possible header keys of a request
@@ -190,6 +190,21 @@ export interface IPutApiRequestType<
 }
 
 /**
+ * Fully describes a PATCH request.
+ *
+ * PUT requests require to provide the "Content-Type" header.
+ */
+export interface IPatchApiRequestType<
+  P,
+  KH extends RequestHeaderKey,
+  Q extends string,
+  R
+> extends IBaseApiRequestType<"patch", P, KH | "Content-Type", Q, R> {
+  readonly method: "patch";
+  readonly body: (params: P) => string | FormData;
+}
+
+/**
  * Fully describes a DELETE request.
  */
 export interface IDeleteApiRequestType<
@@ -213,6 +228,7 @@ export type ApiRequestType<
   | IGetApiRequestType<P, KH, Q, R>
   | IPostApiRequestType<P, KH, Q, R>
   | IPutApiRequestType<P, KH, Q, R>
+  | IPatchApiRequestType<P, KH, Q, R>
   | IDeleteApiRequestType<P, KH, Q, R>;
 
 /**


### PR DESCRIPTION
Add `PATCH` to allowed http methods in our type-safe request data structures.