### PR TITLE
[#ICC-138] Add timezone support to ISO Date from string

### DIFF
--- a/src/__tests__/dates.test.ts
+++ b/src/__tests__/dates.test.ts
@@ -1,10 +1,12 @@
 import {
   DateFromString,
   DateFromTimestamp,
-  UTCISODateFromString
+  IsoDateFromString,
+  TimezoneOnlyIsoDateFromString,
+  UTCISODateFromString,
+  UtcOnlyIsoDateFromString
 } from "../dates";
-
-import { isLeft, isRight } from "fp-ts/lib/Either";
+import { isLeft, isRight } from "fp-ts/Either";
 
 describe("DateFromString", () => {
   it("should validate an ISO string", async () => {
@@ -21,24 +23,62 @@ describe("DateFromString", () => {
   });
 });
 
-describe("UTCISODateFromString", () => {
+describe("UtcOnlyIsoDateFromString", () => {
   it("should validate a full ISO8601 string", async () => {
     const isoDates: ReadonlyArray<string> = [
       new Date().toISOString(),
       "2018-07-10T13:53:03.987Z"
     ];
     isoDates.forEach(isoDate => {
-      const validation = UTCISODateFromString.decode(isoDate);
+      const validation = UtcOnlyIsoDateFromString.decode(isoDate);
       expect(isRight(validation)).toBeTruthy();
-      expect(UTCISODateFromString.is(new Date())).toBeTruthy();
+      expect(UtcOnlyIsoDateFromString.is(new Date())).toBeTruthy();
     });
   });
   it("should fail on invalid full ISO8601 string", async () => {
     const noDates: ReadonlyArray<string> = ["2018-10-13", "2018-10-13 00:00"];
     noDates.forEach(noDate => {
-      const validation = UTCISODateFromString.decode(noDate);
+      const validation = UtcOnlyIsoDateFromString.decode(noDate);
       expect(isLeft(validation)).toBeTruthy();
-      expect(UTCISODateFromString.is(noDate)).toBeFalsy();
+      expect(UtcOnlyIsoDateFromString.is(noDate)).toBeFalsy();
+    });
+  });
+});
+
+describe("TimezoneOnlyIsoDateFromString", () => {
+  it("should decode a valid format", () => {
+    const parsed = TimezoneOnlyIsoDateFromString.decode(
+      "2021-12-22T10:56:03+01:00"
+    );
+    console.log(JSON.stringify(parsed));
+    expect(isRight(parsed)).toBeTruthy();
+  });
+
+  it("should not decode an invalid format", () => {
+    const parsed = TimezoneOnlyIsoDateFromString.decode("2021-12-22T10:56:03Z");
+    expect(isLeft(parsed)).toBeTruthy();
+  });
+});
+
+describe("IsoDateFromString", () => {
+  it("should validate a full ISO8601 string", async () => {
+    const isoDates: ReadonlyArray<string> = [
+      new Date().toISOString(),
+      "2018-07-10T13:53:03.987Z",
+      "2021-12-22T10:56:03+01:00"
+    ];
+    isoDates.forEach(isoDate => {
+      const validation = IsoDateFromString.decode(isoDate);
+      expect(isRight(validation)).toBeTruthy();
+      expect(IsoDateFromString.is(new Date())).toBeTruthy();
+    });
+  });
+  it("should fail on invalid full ISO8601 string", async () => {
+    const noDates: ReadonlyArray<string> = ["2018-10-13", "2018-10-13 00:00"];
+    noDates.forEach(noDate => {
+      const validation = IsoDateFromString.decode(noDate);
+      expect(isLeft(validation)).toBeTruthy();
+      expect(IsoDateFromString.is(noDate)).toBeFalsy();
     });
   });
 });

--- a/src/dates.ts
+++ b/src/dates.ts
@@ -27,39 +27,85 @@ export const DateFromString = new t.Type<Date, string>(
 
 export type DateFromString = t.TypeOf<typeof DateFromString>;
 
+export const patternDateFromString = (
+  pattern: string,
+  tagName: string
+): t.Type<Date, string> =>
+  new t.Type<Date, string>(
+    tagName,
+    isDate,
+    (v, c) =>
+      isDate(v)
+        ? t.success(v)
+        : pipe(
+            PatternString(pattern).validate(v, c),
+            E.chain(s => {
+              const d = new Date(s);
+              return isNaN(d.getTime()) ? t.failure(s, c) : t.success(d);
+            })
+          ),
+    a => a.toISOString()
+  );
+
 /**
  * ISO8601 format for dates.
  *
+ */
+/**
  * Date and time is separated with a capital T.
  * UTC time is defined with a capital letter Z.
  *
  */
-const UTC_ISO8601_FULL_REGEX = PatternString(
-  "^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(Z)?$"
-);
+const UTC_ISO8601_FULL_REGEX =
+  "^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(Z)?$";
+/**
+ * Date and time is separated with a capital T.
+ * Timezone is defined with +/-00:00 format.
+ *
+ */
+const TIMEZONE_ISO8601_FULL_REGEX =
+  "^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?[+-](\\d{2})\\:(\\d{2})$";
 
 /**
  * Accepts only full ISO8601 format with UTC (Z) timezone
  *
  * ie. "2018-10-13T00:00:00.000Z"
  */
-export const UTCISODateFromString = new t.Type<Date, string>(
-  "UTCISODateFromString",
-  isDate,
-  (v, c) =>
-    isDate(v)
-      ? t.success(v)
-      : pipe(
-          UTC_ISO8601_FULL_REGEX.validate(v, c),
-          E.chain(s => {
-            const d = new Date(s);
-            return isNaN(d.getTime()) ? t.failure(s, c) : t.success(d);
-          })
-        ),
-  a => a.toISOString()
+export const UtcOnlyIsoDateFromString = patternDateFromString(
+  UTC_ISO8601_FULL_REGEX,
+  "UtcOnlyIsoDateFromString"
 );
+export type UtcOnlyIsoDateFromString = t.TypeOf<
+  typeof UtcOnlyIsoDateFromString
+>;
 
-export type UTCISODateFromString = t.TypeOf<typeof UTCISODateFromString>;
+/**
+ * Accepts only full ISO8601 format with +/-00:00 timezone
+ *
+ * ie. "2018-10-13T00:00:00.000+00:00"
+ */
+export const TimezoneOnlyIsoDateFromString = patternDateFromString(
+  TIMEZONE_ISO8601_FULL_REGEX,
+  "TimezoneOnlyIsoDateFromString"
+);
+export type TimezoneOnlyIsoDateFromString = t.TypeOf<
+  typeof TimezoneOnlyIsoDateFromString
+>;
+
+export const IsoDateFromString = t.union(
+  [UtcOnlyIsoDateFromString, TimezoneOnlyIsoDateFromString],
+  "IsoDateFromString"
+);
+export type IsoDateFromString = typeof IsoDateFromString;
+
+/**
+ * @deprecated use IsoDateFromString instead.
+ */
+export const UTCISODateFromString = IsoDateFromString;
+/**
+ * @deprecated use IsoDateFromString instead.
+ */
+export type UTCISODateFromString = typeof UTCISODateFromString;
 
 /**
  * Accepts only a valid timestamp format (number)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Extend ISO Date from string to support also date with timezone

#### List of Changes
<!--- Describe your changes in detail -->
Add new decoder for date with timezone
Add new decoder as union fo date utc and with timezone
Deprecate old decoder

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Accept date with timezone inside body response/request

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test 

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.