### PR TITLE
[#ICC-141] Fix type definition for IsoDateFromString

### DIFF
--- a/src/__tests__/dates.test.ts
+++ b/src/__tests__/dates.test.ts
@@ -6,7 +6,8 @@ import {
   UTCISODateFromString,
   UtcOnlyIsoDateFromString
 } from "../dates";
-import { isLeft, isRight } from "fp-ts/Either";
+import { getOrElseW, isLeft, isRight } from "fp-ts/Either";
+import * as t from "io-ts";
 
 describe("DateFromString", () => {
   it("should validate an ISO string", async () => {
@@ -80,6 +81,17 @@ describe("IsoDateFromString", () => {
       expect(isLeft(validation)).toBeTruthy();
       expect(IsoDateFromString.is(noDate)).toBeFalsy();
     });
+  });
+
+  it("isomorphic test", () => {
+    const now = new Date();
+    expect(`${UTCISODateFromString.encode(now)}`).toBe(now.toISOString());
+    expect(
+      isRight(IsoDateFromString.decode(IsoDateFromString.encode(now)))
+    ).toBeTruthy();
+    expect(
+      isRight(UTCISODateFromString.decode(UTCISODateFromString.encode(now)))
+    ).toBeTruthy();
   });
 });
 

--- a/src/dates.ts
+++ b/src/dates.ts
@@ -96,7 +96,7 @@ export const IsoDateFromString = t.union(
   [UtcOnlyIsoDateFromString, TimezoneOnlyIsoDateFromString],
   "IsoDateFromString"
 );
-export type IsoDateFromString = typeof IsoDateFromString;
+export type IsoDateFromString = t.TypeOf<typeof IsoDateFromString>;
 
 /**
  * @deprecated use IsoDateFromString instead.
@@ -105,7 +105,7 @@ export const UTCISODateFromString = IsoDateFromString;
 /**
  * @deprecated use IsoDateFromString instead.
  */
-export type UTCISODateFromString = typeof UTCISODateFromString;
+export type UTCISODateFromString = t.TypeOf<typeof UTCISODateFromString>;
 
 /**
  * Accepts only a valid timestamp format (number)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The IsoDateFromString type is not properly defined as Date.
Typescript can not proper infer the Date type when using the decoder instead of the Date in filed definitions.

#### List of Changes
<!--- Describe your changes in detail -->
Add missing t.TypeOf in type definitions.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allow us to use IsoDateFromString instead of Date.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.