### PR TITLE
Remove undefined values in objects within array

### DIFF
--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -108,19 +108,22 @@ describe("definedValues", () => {
       c: {
         d: [1, 2],
         e: undefined
-      }
+      },
+      f: [{ g: 1, h: undefined }, { i: undefined }]
     };
 
     const newObj = withoutUndefinedValues(obj);
 
-    expect(Object.keys(newObj).length).toEqual(2);
+    expect(Object.keys(newObj).length).toEqual(3);
     expect(Object.keys(newObj.c).length).toEqual(1);
+    expect(newObj.f.length).toEqual(1);
 
     expect(newObj).toEqual({
       a: 1,
       c: {
         d: [1, 2]
-      }
+      },
+      f: [{ g: 1 }]
     });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,24 +125,30 @@ export const isObject = (o: {}): boolean =>
 /**
  * Return an object filtering out keys that point to undefined values.
  */
-export const withoutUndefinedValues = <T, K extends keyof T>(obj: T): T => {
+export const withoutUndefinedValues = <T, K extends keyof T>(input: T): T => {
   // note that T has been already validated by the type system and we can
   // be sure now that only attributes that may be undefined can be actually
   // filtered out by the following code, so the output type T is always
   // a valid T
-  const keys = Object.keys(obj);
-  return keys.reduce((acc, key) => {
-    const value = obj[key as K];
-    return value !== undefined
-      ? {
-          // see https://github.com/Microsoft/TypeScript/pull/13288
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          ...(acc as any),
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          [key]: isObject(value as any) ? withoutUndefinedValues(value) : value
-        }
-      : acc;
-  }, {} as T);
+  if (Array.isArray(input)) {
+    return (
+      (input
+        .map(withoutUndefinedValues)
+        // Remove only the objects that are empty (no keys)
+        .filter(elem =>
+          isObject(elem) ? Object.keys(elem).length > 0 : elem
+        ) as unknown) as T
+    );
+  } else if (isObject(input)) {
+    return Object.keys(input)
+      .filter(key => input[key as K] !== undefined)
+      .reduce(
+        (acc, k) => ({ ...acc, [k]: withoutUndefinedValues(input[k as K]) }),
+        {} as T
+      );
+  } else {
+    return input;
+  }
 };
 
 /**


### PR DESCRIPTION
The method `withoutUndefinedValues` recursively removes the undefined values from objects, but in the case of objects within an array, that wasn't true.

An example is:
```
{a: 1, b: [{c: 2, d:undefined}]}
```

This PR fixes this issue, removing undefined values in objects within an array and propose a refactor that could improve readability.

#### List of Changes
- Add the key into the unit test that breaks the implementation
- Fix implementation considering objects within arrays
- Refactor on the implementation

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
