### PR TITLE
[#IOCIT-361] JwkPublicKeyFromToken decoder support JwkPublicKey inputs

### DIFF
--- a/src/__tests__/jwk.test.ts
+++ b/src/__tests__/jwk.test.ts
@@ -92,6 +92,12 @@ describe("JwkPublicKeyFromToken", () => {
     }
   });
 
+  it("should decode if a JWKPubKey object as input", () => {
+    const result = JwkPublicKeyFromToken.decode(aJwkPublicKey);
+    expect(E.isRight(result)).toBeTruthy();
+    if (E.isRight(result)) expect(result.right).toEqual(aJwkPublicKey);
+  });
+
   it("should encode a correct input", async () => {
     const jwkToken = await getJwkToken();
     const jwk = await jose.exportJWK(jwkToken);
@@ -118,6 +124,11 @@ describe("JwkPublicKeyFromToken", () => {
   it("should guard correctly a wrong input", async () => {
     const result = JwkPublicKeyFromToken.is("");
     expect(result).toBeFalsy();
+  });
+
+  it("should guard if a JWKPubKey object as input", () => {
+    const result = JwkPublicKeyFromToken.is(aJwkPublicKey);
+    expect(result).toBeTruthy();
   });
 });
 

--- a/src/jwk.ts
+++ b/src/jwk.ts
@@ -67,6 +67,12 @@ export const parseJwkOrError = (token: unknown): E.Either<Error, J.Json> =>
         J.parse,
         E.mapLeft(_ => Error("Cannot parse JWK to JSON format"))
       )
+    ),
+    E.orElseW(error =>
+      pipe(
+        token,
+        E.fromPredicate(JwkPublicKey.is, () => error)
+      )
     )
   );
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Change `parseJwkOrError` to support decoding and type guard if the input is a JwkPublicKey object

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To support double encoding operations in codebase, the encoder and the type guard should support `JwkPublicKey` like for other type decoder like `DateFromString`

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.