### PR TITLE
Add Buffer support to openapi client request

### DIFF
--- a/src/requests.ts
+++ b/src/requests.ts
@@ -163,7 +163,9 @@ export interface IPostApiRequestType<
   R
 > extends IBaseApiRequestType<"post", P, KH | "Content-Type", Q, R> {
   readonly method: "post";
-  readonly body: (params: P) => string | FormData | ReadableStream<Uint8Array> | Buffer;
+  readonly body: (
+    params: P
+  ) => string | FormData | ReadableStream<Uint8Array> | Buffer;
 }
 
 /**
@@ -178,7 +180,9 @@ export interface IPutApiRequestType<
   R
 > extends IBaseApiRequestType<"put", P, KH | "Content-Type", Q, R> {
   readonly method: "put";
-  readonly body: (params: P) => string | FormData | ReadableStream<Uint8Array> | Buffer;
+  readonly body: (
+    params: P
+  ) => string | FormData | ReadableStream<Uint8Array> | Buffer;
 }
 
 /**
@@ -193,7 +197,9 @@ export interface IPatchApiRequestType<
   R
 > extends IBaseApiRequestType<"patch", P, KH | "Content-Type", Q, R> {
   readonly method: "patch";
-  readonly body: (params: P) => string | FormData | ReadableStream<Uint8Array> | Buffer;
+  readonly body: (
+    params: P
+  ) => string | FormData | ReadableStream<Uint8Array> | Buffer;
 }
 
 /**

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -163,7 +163,7 @@ export interface IPostApiRequestType<
   R
 > extends IBaseApiRequestType<"post", P, KH | "Content-Type", Q, R> {
   readonly method: "post";
-  readonly body: (params: P) => string | FormData | ReadableStream<Uint8Array>;
+  readonly body: (params: P) => string | FormData | ReadableStream<Uint8Array> | Buffer;
 }
 
 /**
@@ -178,7 +178,7 @@ export interface IPutApiRequestType<
   R
 > extends IBaseApiRequestType<"put", P, KH | "Content-Type", Q, R> {
   readonly method: "put";
-  readonly body: (params: P) => string | FormData | ReadableStream<Uint8Array>;
+  readonly body: (params: P) => string | FormData | ReadableStream<Uint8Array> | Buffer;
 }
 
 /**
@@ -193,7 +193,7 @@ export interface IPatchApiRequestType<
   R
 > extends IBaseApiRequestType<"patch", P, KH | "Content-Type", Q, R> {
   readonly method: "patch";
-  readonly body: (params: P) => string | FormData | ReadableStream<Uint8Array>;
+  readonly body: (params: P) => string | FormData | ReadableStream<Uint8Array> | Buffer;
 }
 
 /**


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
see commit history 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Support a row body parsed as Buffer between the input of a client http request. This will be used by openapi gen to manage raw body in function-app request.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.