### PR TITLE
[#IOCOM-584] Fixed a typo and added a new response

### DIFF
--- a/src/responses.ts
+++ b/src/responses.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 import * as express from "express";
 import * as t from "io-ts";
 
@@ -612,18 +613,18 @@ export function ResponseErrorServiceTemporarilyUnavailable(
   const problem: ProblemJson = {
     detail,
     status,
-    title
+    title,
   };
   return {
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-    apply: res =>
+    apply: (res) =>
       res
         .status(status)
         .set("Content-Type", "application/problem+json")
         .set("Retry-After", retryAfter)
         .json(problem),
     detail: `${title}: ${detail}`,
-    kind: "IResponseErrorServiceUnavailable"
+    kind: "IResponseErrorServiceUnavailable",
   };
 }
 

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -585,14 +585,45 @@ export type IResponseErrorServiceUnavailable =
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function ResponseErrorServiceUnavailable(
   detail: string
-): IResponseErrorInternal {
+): IResponseErrorServiceUnavailable {
   return {
     ...ResponseErrorGeneric(
       HttpStatusCodeEnum.HTTP_STATUS_503,
       "Service temporarily unavailable",
       detail
     ),
-    kind: "IResponseErrorInternal",
+    kind: "IResponseErrorServiceUnavailable",
+  };
+}
+
+/**
+ * Returns a response describing a service temporarily unavailable error.
+ *
+ * @param detail The error message
+ * @param retryAfter seconds to wait for the Retry-After header
+ */
+// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+export function ResponseErrorServiceTemporarilyUnavailable(
+  detail: string,
+  retryAfter: string
+): IResponseErrorServiceUnavailable {
+  const title = "Service temporarily unavailable";
+  const status = HttpStatusCodeEnum.HTTP_STATUS_503;
+  const problem: ProblemJson = {
+    detail,
+    status,
+    title
+  };
+  return {
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    apply: res =>
+      res
+        .status(status)
+        .set("Content-Type", "application/problem+json")
+        .set("Retry-After", retryAfter)
+        .json(problem),
+    detail: `${title}: ${detail}`,
+    kind: "IResponseErrorServiceUnavailable"
   };
 }
 


### PR DESCRIPTION
#### List of Changes
- Fixed a typo for ResponseErrorServiceUnavailable
- Added a new ResponseErrorServiceTemporarilyUnavailable that send a Retry-After header

#### Motivation and Context
We need to send a response that indicates that the resource will be available in short time.
The optimal way (and most common) is to send a 503 with a Retry-After header indicating how many second to wait before retrying.

#### How Has This Been Tested?
build
test
lint

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
